### PR TITLE
Emit error when manager model argument is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,7 @@ And then use `AuthenticatedHttpRequest` instead of the standard `HttpRequest` fo
 
 ### My QuerySet methods are returning Any rather than my Model
 
-`QuerySet.as_manager()` is not currently supported.
-
-If you are using `MyQuerySet.as_manager()`, then your `Manager`/`QuerySet` methods will all not be linked to your model.
+If you are using `MyQuerySet.as_manager()`:
 
 Example:
 
@@ -156,12 +154,12 @@ class MyModel(models.Model):
   bar = models.IntegerField()
   objects = MyModelQuerySet.as_manager()
 
-def use_my_model():
-  foo = MyModel.objects.get(id=1) # This is `Any` but it should be `MyModel`
-  return foo.xyz # No error, but there should be
+def use_my_model() -> int:
+  foo = MyModel.objects.get(id=1) # Should now be `MyModel`
+  return foo.xyz # Gives an error
 ```
 
-There is a workaround: use `Manager.from_queryset` instead.
+Or if you're using `Manager.from_queryset`:
 
 Example:
 
@@ -177,10 +175,13 @@ class MyModel(models.Model):
   bar = models.IntegerField()
   objects = MyModelManager()
 
-def use_my_model():
-  foo = MyModel.objects.get(id=1)
+def use_my_model() -> int:
+  foo = MyModel.objects.get(id=1) # Should now be `MyModel`
   return foo.xyz # Gives an error
 ```
+
+Take note that `.from_queryset` needs to be placed at _module level_ to annotate
+types correctly. Calling `.from_queryset` in class definition will yield an error.
 
 ### How do I annotate cases where I called QuerySet.annotate?
 

--- a/mypy_django_plugin/errorcodes.py
+++ b/mypy_django_plugin/errorcodes.py
@@ -2,3 +2,4 @@ from mypy.errorcodes import ErrorCode
 
 MANAGER_UNTYPED = ErrorCode("django-manager", "Untyped manager disallowed", "Django")
 MANAGER_MISSING = ErrorCode("django-manager-missing", "Couldn't resolve manager for model", "Django")
+MODEL_ARG_MISMATCH = ErrorCode("django-model-arg", "Model argument mismatching between manager and queryset", "Django")

--- a/mypy_django_plugin/lib/helpers.py
+++ b/mypy_django_plugin/lib/helpers.py
@@ -376,33 +376,31 @@ def bind_or_analyze_type(t: MypyType, api: SemanticAnalyzer, module_name: Option
 
 
 def copy_method_to_another_class(
-    ctx: ClassDefContext,
+    api: SemanticAnalyzer,
+    cls: ClassDef,
     self_type: Instance,
     new_method_name: str,
     method_node: FuncDef,
     return_type: Optional[MypyType] = None,
     original_module_name: Optional[str] = None,
 ) -> None:
-    semanal_api = get_semanal_api(ctx)
     if method_node.type is None:
-        if not semanal_api.final_iteration:
-            semanal_api.defer()
+        if not api.final_iteration:
+            api.defer()
             return
 
         arguments, return_type = build_unannotated_method_args(method_node)
-        add_method_to_class(
-            semanal_api, ctx.cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type
-        )
+        add_method_to_class(api, cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type)
         return
 
     method_type = method_node.type
     if not isinstance(method_type, CallableType):
-        if not semanal_api.final_iteration:
-            semanal_api.defer()
+        if not api.final_iteration:
+            api.defer()
         return
 
     if return_type is None:
-        return_type = bind_or_analyze_type(method_type.ret_type, semanal_api, original_module_name)
+        return_type = bind_or_analyze_type(method_type.ret_type, api, original_module_name)
     if return_type is None:
         return
 
@@ -415,7 +413,7 @@ def copy_method_to_another_class(
         zip(method_type.arg_types[1:], method_type.arg_kinds[1:], method_type.arg_names[1:]),
         start=1,
     ):
-        bound_arg_type = bind_or_analyze_type(arg_type, semanal_api, original_module_name)
+        bound_arg_type = bind_or_analyze_type(arg_type, api, original_module_name)
         if bound_arg_type is None:
             return
         if arg_name is None and hasattr(method_node, "arguments"):
@@ -431,9 +429,7 @@ def copy_method_to_another_class(
             )
         )
 
-    add_method_to_class(
-        semanal_api, ctx.cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type
-    )
+    add_method_to_class(api, cls, new_method_name, args=arguments, return_type=return_type, self_type=self_type)
 
 
 def add_new_manager_base(api: SemanticAnalyzerPluginInterface, fullname: str) -> None:

--- a/mypy_django_plugin/main.py
+++ b/mypy_django_plugin/main.py
@@ -304,13 +304,12 @@ class NewSemanalDjangoPlugin(Plugin):
 
     def get_dynamic_class_hook(self, fullname: str) -> Optional[Callable[[DynamicClassDefContext], None]]:
         # Create a new manager class definition when a manager's '.from_queryset' classmethod is called
-        if fullname.endswith(".from_queryset"):
-            class_name, _, _ = fullname.rpartition(".")
+        class_name, _, method_name = fullname.rpartition(".")
+        if method_name == "from_queryset":
             info = self._get_typeinfo_or_none(class_name)
             if info and info.has_base(fullnames.BASE_MANAGER_CLASS_FULLNAME):
                 return create_new_manager_class_from_from_queryset_method
-        elif fullname.endswith(".as_manager"):
-            class_name, _, _ = fullname.rpartition(".")
+        elif method_name == "as_manager":
             info = self._get_typeinfo_or_none(class_name)
             if info and info.has_base(fullnames.QUERYSET_CLASS_FULLNAME):
                 return create_new_manager_class_from_as_manager_method

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -221,7 +221,7 @@ def merge_queryset_into_manager(
             helpers.add_new_sym_for_info(
                 manager_info,
                 name=name,
-                sym_type=AnyType(TypeOfAny.special_form),
+                sym_type=AnyType(TypeOfAny.implementation_artifact),
             )
 
     # For methods on BaseManager that return a queryset we need to update the
@@ -233,7 +233,7 @@ def merge_queryset_into_manager(
         helpers.add_new_sym_for_info(
             manager_info,
             name=name,
-            sym_type=AnyType(TypeOfAny.special_form),
+            sym_type=AnyType(TypeOfAny.implementation_artifact),
         )
 
 

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -155,8 +155,10 @@ def resolve_manager_method(ctx: AttributeContext) -> MypyType:
     A 'get_attribute_hook' that is intended to be invoked whenever the TypeChecker encounters
     an attribute on a class that has 'django.db.models.BaseManager' as a base.
     """
-    # Skip (method) type that is currently something other than Any
+    # Skip (method) type that is currently something other than Any of type `implementation_artifact`
     if not isinstance(ctx.default_attr_type, AnyType):
+        return ctx.default_attr_type
+    elif ctx.default_attr_type.type_of_any != TypeOfAny.implementation_artifact:
         return ctx.default_attr_type
 
     # (Current state is:) We wouldn't end up here when looking up a method from a custom _manager_.

--- a/mypy_django_plugin/transformers/managers.py
+++ b/mypy_django_plugin/transformers/managers.py
@@ -303,18 +303,13 @@ def create_new_manager_class_from_from_queryset_method(ctx: DynamicClassDefConte
     new_manager_info.defn.line = ctx.call.line
     new_manager_info.metaclass_type = new_manager_info.calculate_metaclass_type()
 
-    try:
-        merge_queryset_into_manager(
-            api=semanal_api,
-            manager_info=new_manager_info,
-            queryset_info=queryset_info,
-            manager_base=manager_base,
-            class_name=manager_class_name,
-        )
-    except helpers.IncompleteDefnException:
-        if not semanal_api.final_iteration:
-            semanal_api.defer()
-        return
+    merge_queryset_into_manager(
+        api=semanal_api,
+        manager_info=new_manager_info,
+        queryset_info=queryset_info,
+        manager_base=manager_base,
+        class_name=manager_class_name,
+    )
 
     symbol_kind = semanal_api.current_symbol_kind()
     # Annotate the module variable as `<Variable>: Type[<NewManager[Any]>]` as the model
@@ -396,18 +391,13 @@ def create_new_manager_class_from_as_manager_method(ctx: DynamicClassDefContext)
         new_manager_info.defn.type_vars = manager_base.defn.type_vars
         new_manager_info.defn.line = ctx.call.line
 
-        try:
-            merge_queryset_into_manager(
-                api=semanal_api,
-                manager_info=new_manager_info,
-                queryset_info=queryset_info,
-                manager_base=manager_base,
-                class_name=manager_class_name,
-            )
-        except helpers.IncompleteDefnException:
-            if not semanal_api.final_iteration:
-                semanal_api.defer()
-            return
+        merge_queryset_into_manager(
+            api=semanal_api,
+            manager_info=new_manager_info,
+            queryset_info=queryset_info,
+            manager_base=manager_base,
+            class_name=manager_class_name,
+        )
 
     # Whenever `<QuerySet>.as_manager()` isn't called at class level, we want to ensure
     # that the variable is an instance of our generated manager. Instead of the return

--- a/mypy_django_plugin/transformers/models.py
+++ b/mypy_django_plugin/transformers/models.py
@@ -206,14 +206,14 @@ class AddManagers(ModelClassInitializer):
 
         new_manager_info = self.add_new_class_for_current_module(name, bases)
         # copy fields to a new manager
-        new_cls_def_context = ClassDefContext(cls=new_manager_info.defn, reason=self.ctx.reason, api=self.api)
         custom_manager_type = Instance(new_manager_info, [Instance(self.model_classdef.info, [])])
 
         for name, sym in base_manager_info.names.items():
             # replace self type with new class, if copying method
             if isinstance(sym.node, FuncDef):
                 helpers.copy_method_to_another_class(
-                    new_cls_def_context,
+                    api=self.api,
+                    cls=new_manager_info.defn,
                     self_type=custom_manager_type,
                     new_method_name=name,
                     method_node=sym.node,

--- a/tests/typecheck/fields/test_related.yml
+++ b/tests/typecheck/fields/test_related.yml
@@ -680,18 +680,22 @@
 
                 # Note, that we cannot resolve dynamic calls for custom managers:
                 class Transaction(models.Model):
-                    objects = BaseManager.from_queryset(TransactionQuerySet)
+                    objects = BaseManager.from_queryset(TransactionQuerySet)()
                     def test(self) -> None:
                         reveal_type(self.transactionlog_set)
+                        reveal_type(Transaction.objects)
                         # We use a fallback Any type:
                         reveal_type(Transaction.objects.custom())
 
                 class TransactionLog(models.Model):
                     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
     out: |
+        myapp/models:9: error: Could not resolve manager type for "myapp.models.Transaction.objects"
         myapp/models:9: error: `.from_queryset` called from inside model class body
         myapp/models:11: note: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.TransactionLog]"
-        myapp/models:13: note: Revealed type is "Any"
+        myapp/models:12: note: Revealed type is "django.db.models.manager.Manager[myapp.models.Transaction]"
+        myapp/models:14: error: "Manager[Transaction]" has no attribute "custom"
+        myapp/models:14: note: Revealed type is "Any"
 
 
 -   case: resolve_primary_keys_for_foreign_keys_with_abstract_self_model

--- a/tests/typecheck/managers/querysets/test_as_manager.yml
+++ b/tests/typecheck/managers/querysets/test_as_manager.yml
@@ -1,0 +1,192 @@
+-   case: declares_manager_type_like_django
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromMyQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class MyQuerySet(models.QuerySet):
+                    ...
+
+                class MyModel(models.Model):
+                    objects = MyQuerySet.as_manager()
+
+-   case: includes_django_methods_returning_queryset
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects.none)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all)  # N: Revealed type is "def () -> myapp.models.MyQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.filter)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> myapp.models.MyQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class MyQuerySet(models.QuerySet):
+                    ...
+
+                class MyModel(models.Model):
+                    objects = MyQuerySet.as_manager()
+
+-   case: model_gets_generated_manager_as_default_manager
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "builtins.str"
+        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet):
+                    def queryset_method(self) -> str:
+                        return 'hello'
+
+                class MyModel(models.Model):
+                    objects = ModelQuerySet.as_manager()
+
+-   case: resolves_name_collision_with_other_module_level_object
+    main: |
+        from myapp.models import MyModel, ManagerFromModelQuerySet
+        reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "builtins.int"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
+        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                ManagerFromModelQuerySet = 1
+
+                class ModelQuerySet(models.QuerySet):
+                    ...
+
+                class MyModel(models.Model):
+                    objects = ModelQuerySet.as_manager()
+
+-   case: includes_custom_queryset_methods
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects.custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects.all().custom_queryset_method())  # N: Revealed type is "myapp.models.ModelQuerySet"
+        reveal_type(MyModel.objects.returns_int_sequence())  # N: Revealed type is "typing.Sequence[builtins.int]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from typing import Sequence
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    def custom_queryset_method(self) -> "ModelQuerySet":
+                        return self.all()
+
+                    def returns_int_sequence(self) -> Sequence[int]:
+                      return [1]
+
+                class MyModel(models.Model):
+                    objects = ModelQuerySet.as_manager()
+
+-   case: handles_call_outside_of_model_class_definition
+    main: |
+        from myapp.models import MyModel, MyModelManager
+        reveal_type(MyModelManager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[Any]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    ...
+
+                MyModelManager = ModelQuerySet.as_manager()
+                class MyModel(models.Model):
+                    objects = MyModelManager
+
+-   case: handles_name_collision_when_declared_outside_of_model_class_body
+    main: |
+        from myapp.models import MyModel, ManagerFromModelQuerySet
+        reveal_type(ManagerFromModelQuerySet)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[Any]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    ...
+
+                ManagerFromModelQuerySet = ModelQuerySet.as_manager()
+                class MyModel(models.Model):
+                    objects = ManagerFromModelQuerySet
+
+-   case: reuses_generated_type_when_called_identically_for_multiple_managers
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects_1)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects_2)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects_1.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects_2.all())  # N: Revealed type is "myapp.models.ModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    ...
+
+                class MyModel(models.Model):
+                    objects_1 = ModelQuerySet.as_manager()
+                    objects_2 = ModelQuerySet.as_manager()
+
+-   case: generates_new_manager_class_when_name_colliding_with_explicit_manager
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet1[myapp.models.MyModel]"
+        reveal_type(MyModel.objects.custom_method())  # N: Revealed type is "builtins.int"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ManagerFromModelQuerySet(models.Manager):
+                    ...
+
+                class ModelQuerySet(models.QuerySet["MyModel"]):
+                    def custom_method(self) -> int:
+                        return 1
+
+                class MyModel(models.Model):
+                    objects = ModelQuerySet.as_manager()

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -1,7 +1,7 @@
 -   case: from_queryset_with_base_manager
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
         reveal_type(MyModel.objects.filter(id=1).queryset_method()) # N: Revealed type is "builtins.str"
@@ -25,8 +25,8 @@
 -   case: from_queryset_queryset_imported_from_other_module
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[myapp.querysets.Custom]"
@@ -74,7 +74,7 @@
 -   case: from_queryset_generated_manager_imported_from_other_module
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.querysets.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.querysets.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "myapp.querysets.ModelQuerySet"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "typing.Iterable[myapp.querysets.Custom]"
@@ -120,10 +120,27 @@
                 class MyModel(models.Model):
                     objects = NewManager()
 
+-   case: from_queryset_annotates_manager_variable_as_type
+    main: |
+        from myapp.models import NewManager
+        reveal_type(NewManager)  # N: Revealed type is "Type[myapp.models.ManagerFromModelQuerySet[Any]]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+
+                class ModelQuerySet(models.QuerySet):
+                    ...
+
+                NewManager = models.Manager.from_queryset(ModelQuerySet)
+
 -   case: from_queryset_with_manager
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
     installed_apps:
@@ -145,8 +162,8 @@
 -   case: from_queryset_returns_intersection_of_manager_and_queryset
     main: |
         from myapp.models import MyModel, NewManager
-        reveal_type(NewManager())  # N: Revealed type is "myapp.models.NewManager"
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(NewManager())  # N: Revealed type is "myapp.models.ModelBaseManagerFromModelQuerySet"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ModelBaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "Any"
         reveal_type(MyModel.objects.manager_only_method())  # N: Revealed type is "builtins.int"
         reveal_type(MyModel.objects.manager_and_queryset_method())  # N: Revealed type is "builtins.str"
@@ -170,12 +187,16 @@
 
 -   case: from_queryset_with_class_name_provided
     main: |
-        from myapp.models import MyModel, NewManager
+        from myapp.models import MyModel, NewManager, OtherModel, OtherManager
         reveal_type(NewManager())  # N: Revealed type is "myapp.models.NewManager"
         reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
         reveal_type(MyModel.objects.get())  # N: Revealed type is "Any"
         reveal_type(MyModel.objects.manager_only_method())  # N: Revealed type is "builtins.int"
         reveal_type(MyModel.objects.manager_and_queryset_method())  # N: Revealed type is "builtins.str"
+        reveal_type(OtherManager())  # N: Revealed type is "myapp.models.X"
+        reveal_type(OtherModel.objects)  # N: Revealed type is "myapp.models.X[myapp.models.OtherModel]"
+        reveal_type(OtherModel.objects.manager_only_method())  # N: Revealed type is "builtins.int"
+        reveal_type(OtherModel.objects.manager_and_queryset_method())  # N: Revealed type is "builtins.str"
     installed_apps:
         - myapp
     files:
@@ -194,10 +215,14 @@
                 class MyModel(models.Model):
                     objects = NewManager()
 
+                OtherManager = ModelBaseManager.from_queryset(ModelQuerySet, class_name='X')
+                class OtherModel(models.Model):
+                    objects = OtherManager()
+
 -   case: from_queryset_with_class_inheritance
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
     installed_apps:
@@ -221,7 +246,7 @@
 -   case: from_queryset_with_manager_in_another_directory_and_imports
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel().objects.queryset_method)  # N: Revealed type is "def (param: Union[builtins.str, None] =) -> Union[builtins.str, None]"
         reveal_type(MyModel().objects.queryset_method('str'))  # N: Revealed type is "Union[builtins.str, None]"
@@ -251,7 +276,7 @@
     disable_cache: true
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.managers.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.get())  # N: Revealed type is "myapp.models.MyModel"
         reveal_type(MyModel().objects.base_queryset_method)  # N: Revealed type is "def (param: Union[builtins.int, builtins.str]) -> <nothing>"
         reveal_type(MyModel().objects.base_queryset_method(2))  # N: Revealed type is "<nothing>"
@@ -283,7 +308,7 @@
 -   case: from_queryset_with_decorated_queryset_methods
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel().objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel().objects.queryset_method())  # N: Revealed type is "builtins.str"
         reveal_type(MyModel.objects.queryset_method_2())  # N: Revealed type is "builtins.int"
     installed_apps:
@@ -311,9 +336,9 @@
 -   case: from_queryset_model_gets_generated_manager_as_default_manager
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method())  # N: Revealed type is "builtins.str"
-        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel._default_manager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
     installed_apps:
         - myapp
     files:
@@ -333,7 +358,7 @@
 -   case: from_queryset_can_resolve_explicit_any_methods
     main: |
         from myapp.models import MyModel
-        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.NewManager[myapp.models.MyModel]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.MyManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.objects.queryset_method(1))  # N: Revealed type is "Any"
         reveal_type(MyModel.objects.queryset_method)  # N: Revealed type is "def (qarg: Any) -> Any"
         reveal_type(MyModel.objects.manager_method(2))  # N: Revealed type is "Any"
@@ -435,7 +460,6 @@
                 class MyModel(models.Model):
                     objects = MyManager()
 
-
 # This tests a regression where mypy would generate phantom warnings about
 # undefined types due to unresolved types when copying methods from QuerySet to
 # a manager dynamically created using Manager.from_queryset().
@@ -475,3 +499,49 @@
 
                 class UserQuerySet(models.QuerySet["User"]):
                     pass
+
+-   case: reuses_type_when_called_twice_identically
+    main: |
+        from myapp.models import MyModel, FirstManager, SecondManager
+        reveal_type(FirstManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+        reveal_type(SecondManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.first)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(MyModel.second)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                  ...
+
+              FirstManager = BaseManager.from_queryset(ModelQuerySet)
+              SecondManager = BaseManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  first = FirstManager()
+                  second = SecondManager()
+
+-   case: handles_name_collision_with_generated_type
+    main: |
+        from myapp.models import MyModel, BaseManagerFromModelQuerySet
+        reveal_type(BaseManagerFromModelQuerySet())  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[<nothing>]"
+        reveal_type(MyModel.objects)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                  ...
+
+              BaseManagerFromModelQuerySet = BaseManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  objects = BaseManagerFromModelQuerySet()

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -545,3 +545,41 @@
               BaseManagerFromModelQuerySet = BaseManager.from_queryset(ModelQuerySet)
               class MyModel(models.Model):
                   objects = BaseManagerFromModelQuerySet()
+
+-   case: accepts_explicit_none_as_class_name
+    main: |
+        from myapp.models import PositionalNone, NoneAsKwarg
+        reveal_type(PositionalNone)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+        reveal_type(NoneAsKwarg)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet):
+                  ...
+
+              PositionalNone = BaseManager.from_queryset(ModelQuerySet, None)
+              NoneAsKwarg = BaseManager.from_queryset(ModelQuerySet, class_name=None)
+
+-   case: uses_fallback_class_name_when_argument_is_not_string_expression
+    main: |
+        from myapp.models import StrCallable
+        reveal_type(StrCallable)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet):
+                  ...
+
+              StrCallable = BaseManager.from_queryset(ModelQuerySet, class_name=str(1))

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -584,7 +584,7 @@
 
               StrCallable = BaseManager.from_queryset(ModelQuerySet, class_name=str(1))
 
--   case: yields_error_when_mismatching_manager_and_queryset_model_args
+-   case: emits_error_when_mismatching_manager_and_queryset_model_args
     main: |
         from myapp.models import FromBaseManager, FromManager, MyModel
         reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[Any]]"
@@ -592,8 +592,10 @@
         reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[Any]]"
         reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[Any]"
     out: |
-        myapp/models:13: error: Manager model argument not matching queryset model argument
-        myapp/models:14: error: Manager model argument not matching queryset model argument
+        myapp/models:13: error: Manager model argument does not match queryset model argument
+        myapp/models:14: error: Manager model argument does not match queryset model argument
+        myapp/models:16: error: Manager model argument does not match model it is assigned to
+        myapp/models:17: error: Manager model argument does not match model it is assigned to
     installed_apps:
         - myapp
     files:

--- a/tests/typecheck/managers/querysets/test_from_queryset.yml
+++ b/tests/typecheck/managers/querysets/test_from_queryset.yml
@@ -503,8 +503,8 @@
 -   case: reuses_type_when_called_twice_identically
     main: |
         from myapp.models import MyModel, FirstManager, SecondManager
-        reveal_type(FirstManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
-        reveal_type(SecondManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+        reveal_type(FirstManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(SecondManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]]"
         reveal_type(MyModel.first)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
         reveal_type(MyModel.second)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
     installed_apps:
@@ -583,3 +583,228 @@
                   ...
 
               StrCallable = BaseManager.from_queryset(ModelQuerySet, class_name=str(1))
+
+-   case: yields_error_when_mismatching_manager_and_queryset_model_args
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseModelManagerFromModelQuerySet[Any]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[Any]"
+    out: |
+        myapp/models:13: error: Manager model argument not matching queryset model argument
+        myapp/models:14: error: Manager model argument not matching queryset model argument
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                  ...
+
+              class BaseModelManager(BaseManager["OtherModel"]):
+                  ...
+
+              class ManagerModelManager(models.Manager["OtherModel"]):
+                  ...
+
+              FromBaseManager = BaseModelManager.from_queryset(ModelQuerySet)
+              FromManager = ManagerModelManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+              class OtherModel(models.Model):
+                  ...
+
+-   case: populates_model_arg_from_manager_when_missing_on_queryset
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet):
+                  ...
+
+              class BaseModelManager(BaseManager["MyModel"]):
+                  ...
+
+              class ManagerModelManager(models.Manager["MyModel"]):
+                  ...
+
+              FromBaseManager = BaseModelManager.from_queryset(ModelQuerySet)
+              FromManager = ManagerModelManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+-   case: populates_model_arg_from_queryset_when_missing_on_manager
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                  ...
+
+              class BaseModelManager(BaseManager):
+                  ...
+
+              class ManagerModelManager(models.Manager):
+                  ...
+
+              FromBaseManager = BaseModelManager.from_queryset(ModelQuerySet)
+              FromManager = ManagerModelManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+-   case: populates_model_arg_from_queryset_when_manager_base_is_django_builtin_manager
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                  ...
+
+              FromBaseManager = BaseManager.from_queryset(ModelQuerySet)
+              FromManager = models.Manager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+-   case: populates_model_arg_from_manager_when_queryset_is_django_builtin
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseModelManagerFromQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models import QuerySet
+              from django.db.models.manager import BaseManager
+
+              class BaseModelManager(BaseManager["MyModel"]):
+                  ...
+
+              class ManagerModelManager(models.Manager["MyModel"]):
+                  ...
+
+              FromBaseManager = BaseModelManager.from_queryset(QuerySet)
+              FromManager = ManagerModelManager.from_queryset(QuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+-   case: populates_model_arg_as_any_when_no_args_specified
+    main: |
+        from myapp.models import FromCustomBaseManager, FromCustomManager, FromBaseManager, FromManager, MyModel
+        reveal_type(FromCustomBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.custom_base)  # N: Revealed type is "myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromCustomManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.custom_manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerFromModelQuerySet[Any]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models import QuerySet
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet):
+                ...
+
+              class BaseModelManager(BaseManager):
+                  ...
+
+              class ManagerModelManager(models.Manager):
+                  ...
+
+              FromCustomBaseManager = BaseModelManager.from_queryset(ModelQuerySet)
+              FromCustomManager = ManagerModelManager.from_queryset(ModelQuerySet)
+              FromBaseManager = BaseManager.from_queryset(ModelQuerySet)
+              FromManager = models.Manager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  custom_base = FromCustomBaseManager()
+                  custom_manager = FromCustomManager()
+                  base = FromBaseManager()
+                  manager = FromManager()
+
+-   case: populates_model_arg_when_same_for_manager_and_queryset
+    main: |
+        from myapp.models import FromBaseManager, FromManager, MyModel
+        reveal_type(FromBaseManager)  # N: Revealed type is "Type[myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.base)  # N: Revealed type is "myapp.models.BaseModelManagerFromModelQuerySet[myapp.models.MyModel]"
+        reveal_type(FromManager)  # N: Revealed type is "Type[myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]]"
+        reveal_type(MyModel.manager)  # N: Revealed type is "myapp.models.ManagerModelManagerFromModelQuerySet[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        - path: myapp/__init__.py
+        - path: myapp/models.py
+          content: |
+              from django.db import models
+              from django.db.models import QuerySet
+              from django.db.models.manager import BaseManager
+
+              class ModelQuerySet(models.QuerySet["MyModel"]):
+                ...
+
+              class BaseModelManager(BaseManager["MyModel"]):
+                  ...
+
+              class ManagerModelManager(models.Manager["MyModel"]):
+                  ...
+
+              FromBaseManager = BaseModelManager.from_queryset(ModelQuerySet)
+              FromManager = ManagerModelManager.from_queryset(ModelQuerySet)
+              class MyModel(models.Model):
+                  base = FromBaseManager()
+                  manager = FromManager()

--- a/tests/typecheck/managers/querysets/test_union_type.yml
+++ b/tests/typecheck/managers/querysets/test_union_type.yml
@@ -9,7 +9,7 @@
         model_cls = type(instance)
 
         reveal_type(model_cls) # N: Revealed type is "Union[Type[myapp.models.Order], Type[myapp.models.User]]"
-        reveal_type(model_cls.objects)  # N: Revealed type is "Union[myapp.models.OrderManager[myapp.models.Order], myapp.models.UserManager[myapp.models.User]]"
+        reveal_type(model_cls.objects)  # N: Revealed type is "Union[myapp.models.ManagerFromMyQuerySet[myapp.models.Order], myapp.models.ManagerFromMyQuerySet[myapp.models.User]]"
         model_cls.objects.my_method()  # E: Unable to resolve return type of queryset/manager method "my_method"
     installed_apps:
         - myapp

--- a/tests/typecheck/managers/test_managers.yml
+++ b/tests/typecheck/managers/test_managers.yml
@@ -521,3 +521,90 @@
         myapp/models:47: note: Revealed type is "django.db.models.manager.BaseManager[myapp.models.InvisibleUnresolvable]"
         myapp/models:49: note: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Booking]"
         myapp/models:50: note: Revealed type is "django.db.models.manager.RelatedManager[myapp.models.Booking]"
+
+-   case: emits_error_when_manager_model_arg_does_not_match_model
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.from_manager)  # N: Revealed type is "myapp.models.FromManager[Any]"
+        reveal_type(MyModel.from_base_manager)  # N: Revealed type is "myapp.models.FromBaseManager[Any]"
+    out: |
+        myapp/models:11: error: Manager model argument does not match model it is assigned to
+        myapp/models:12: error: Manager model argument does not match model it is assigned to
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+
+                class FromManager(models.Manager["OtherModel"]):
+                    ...
+
+                class FromBaseManager(BaseManager["OtherModel"]):
+                    ...
+
+                class MyModel(models.Model):
+                    from_manager = FromManager()
+                    from_base_manager = FromBaseManager()
+
+                class OtherModel(models.Model):
+                    ...
+
+-   case: emits_error_when_imported_manager_model_arg_does_not_match_model
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.from_manager)  # N: Revealed type is "myapp.managers.FromManager[Any]"
+        reveal_type(MyModel.from_base_manager)  # N: Revealed type is "myapp.managers.FromBaseManager[Any]"
+    out: |
+        myapp/models:5: error: Manager model argument does not match model it is assigned to
+        myapp/models:6: error: Manager model argument does not match model it is assigned to
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from .managers import FromManager, FromBaseManager
+
+                class MyModel(models.Model):
+                    from_manager = FromManager()
+                    from_base_manager = FromBaseManager()
+
+                class OtherModel(models.Model):
+                    ...
+        -   path: myapp/managers.py
+            content: |
+                from typing import TYPE_CHECKING
+                from django.db import models
+                from django.db.models.manager import BaseManager
+
+                if TYPE_CHECKING:
+                    from .models import OtherModel
+
+                class FromManager(models.Manager["OtherModel"]):
+                    ...
+
+                class FromBaseManager(BaseManager["OtherModel"]):
+                    ...
+
+-   case: populates_manager_model_arg_for_django_builtin_managers
+    main: |
+        from myapp.models import MyModel
+        reveal_type(MyModel.from_manager)  # N: Revealed type is "django.db.models.manager.Manager[myapp.models.MyModel]"
+        reveal_type(MyModel.from_base_manager)  # N: Revealed type is "django.db.models.manager.BaseManager[myapp.models.MyModel]"
+    installed_apps:
+        - myapp
+    files:
+        -   path: myapp/__init__.py
+        -   path: myapp/models.py
+            content: |
+                from django.db import models
+                from django.db.models.manager import BaseManager
+
+                class MyModel(models.Model):
+                    from_manager = models.Manager()
+                    # TODO: Why do get complaint that we "Need type annotation ..."?
+                    from_base_manager: BaseManager = BaseManager()


### PR DESCRIPTION
- Model won't define a manager if manager model argument doesn't match model
- Creating a dynamic manager where manager model argument doesn't match queryset model argument will now emit an error
- Manager type created via `.from_queryset` will now populate its model argument (as long as it's correct)

## Related issues

https://github.com/typeddjango/django-stubs/pull/1025#discussion_r911414378